### PR TITLE
handle long token title text

### DIFF
--- a/CLTokenInput/CLTokenInput.h
+++ b/CLTokenInput/CLTokenInput.h
@@ -20,3 +20,4 @@ FOUNDATION_EXPORT const unsigned char CLTokenInputVersionString[];
 #import <CLTokenInput/CLTokenView.h>
 #import <CLTokenInput/CLTokenPillView.h>
 #import <CLTokenInput/CLToken.h>
+#import <CLTokenInput/CLBackspaceDetectingTextField.h>

--- a/CLTokenInputView.xcodeproj/project.pbxproj
+++ b/CLTokenInputView.xcodeproj/project.pbxproj
@@ -12,12 +12,12 @@
 		43758B26216D26E3000F3786 /* CLTokenPillView.h in Headers */ = {isa = PBXBuildFile; fileRef = 43758B21216D26E3000F3786 /* CLTokenPillView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		43758B2E216E2539000F3786 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 43758B2D216E2539000F3786 /* Media.xcassets */; };
 		43758B2F216E2539000F3786 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 43758B2D216E2539000F3786 /* Media.xcassets */; };
+		43858594218108E800AA0853 /* CLBackspaceDetectingTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = 65B16BBC18BC1D9E003AA819 /* CLBackspaceDetectingTextField.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		498307481CDAA5E1007A0877 /* CLTokenInput.h in Headers */ = {isa = PBXBuildFile; fileRef = 498307471CDAA5E1007A0877 /* CLTokenInput.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4983074F1CDAA5E2007A0877 /* CLTokenInput.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 498307451CDAA5E1007A0877 /* CLTokenInput.framework */; };
 		498307541CDAA5E2007A0877 /* CLTokenInputTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 498307531CDAA5E2007A0877 /* CLTokenInputTests.m */; };
 		4983075C1CDAA605007A0877 /* CLTokenInputView.h in Headers */ = {isa = PBXBuildFile; fileRef = 65B16BAD18BC17D2003AA819 /* CLTokenInputView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4983075D1CDAA605007A0877 /* CLTokenView.h in Headers */ = {isa = PBXBuildFile; fileRef = 65B16BB118BC17EC003AA819 /* CLTokenView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4983075E1CDAA605007A0877 /* CLBackspaceDetectingTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = 65B16BBC18BC1D9E003AA819 /* CLBackspaceDetectingTextField.h */; };
 		4983075F1CDAA605007A0877 /* CLToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 65B16BC018BC26C9003AA819 /* CLToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		498307601CDAA6DF007A0877 /* CLTokenInputView.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BAE18BC17D2003AA819 /* CLTokenInputView.m */; };
 		498307611CDAA6DF007A0877 /* CLTokenView.m in Sources */ = {isa = PBXBuildFile; fileRef = 65B16BB218BC17EC003AA819 /* CLTokenView.m */; };
@@ -273,7 +273,7 @@
 				4983075D1CDAA605007A0877 /* CLTokenView.h in Headers */,
 				43758B26216D26E3000F3786 /* CLTokenPillView.h in Headers */,
 				4983075F1CDAA605007A0877 /* CLToken.h in Headers */,
-				4983075E1CDAA605007A0877 /* CLBackspaceDetectingTextField.h in Headers */,
+				43858594218108E800AA0853 /* CLBackspaceDetectingTextField.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenInputView.m
@@ -250,10 +250,11 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
 
     // Position token views
     CGRect tokenRect = CGRectNull;
-    for (UIView *tokenView in self.tokenViews) {
+    for (CLTokenView *tokenView in self.tokenViews) {
         tokenRect = tokenView.frame;
 
         CGFloat tokenBoundary = isOnFirstLine ? firstLineRightBoundary : rightBoundary;
+        // if token is too wide for the current line, move to the next line
         if (curX + CGRectGetWidth(tokenRect) > tokenBoundary) {
             // Need a new line
             curX = self.paddingInsets.left;
@@ -261,7 +262,16 @@ static CGFloat const FIELD_MARGIN_X = 4.0; // Note: Same as CLTokenView.PADDING_
             totalHeight += STANDARD_ROW_HEIGHT;
             isOnFirstLine = NO;
         }
-
+        // if token is still to wide for the current line, resize the width of the token so it fits
+        if (curX + CGRectGetWidth(tokenRect) > tokenBoundary) {
+            tokenView.maxWidth = tokenBoundary - curX;
+            CGSize tokenViewIntrinsicSize = tokenView.intrinsicContentSize;
+            tokenView.frame = CGRectMake(tokenView.frame.origin.x, tokenView.frame.origin.y, tokenViewIntrinsicSize.width, tokenViewIntrinsicSize.height);
+            [tokenView setNeedsLayout];
+            [tokenView layoutIfNeeded];
+            tokenRect = tokenView.frame;
+        }
+        
         tokenRect.origin.x = curX;
         // Center our tokenView vertically within STANDARD_ROW_HEIGHT
         tokenRect.origin.y = curY + ((STANDARD_ROW_HEIGHT-CGRectGetHeight(tokenRect))/2.0);

--- a/CLTokenInputView/CLTokenInputView/CLTokenView.h
+++ b/CLTokenInputView/CLTokenInputView/CLTokenView.h
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic, nullable) NSObject <CLTokenViewDelegate> *delegate;
 @property (assign, nonatomic) BOOL selected;
 @property (assign, nonatomic) BOOL hideUnselectedComma;
+@property (assign, nonatomic) CGFloat maxWidth;
 
 - (id)initWithToken:(CLToken *)token font:(nullable UIFont *)font;
 

--- a/CLTokenInputView/CLTokenInputView/CLTokenView.m
+++ b/CLTokenInputView/CLTokenInputView/CLTokenView.m
@@ -70,6 +70,8 @@ static NSString *const UNSELECTED_LABEL_NO_COMMA_FORMAT = @"%@";
         // Listen for taps
         UITapGestureRecognizer *tapRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleTapGestureRecognizer:)];
         [self addGestureRecognizer:tapRecognizer];
+        
+        self.maxWidth = CGFLOAT_MAX;
 
         [self setNeedsLayout];
 
@@ -82,14 +84,16 @@ static NSString *const UNSELECTED_LABEL_NO_COMMA_FORMAT = @"%@";
 - (CGSize)intrinsicContentSize
 {
     CGSize labelIntrinsicSize = self.selectedLabel.intrinsicContentSize;
-    return CGSizeMake(labelIntrinsicSize.width+(2.0*PADDING_X), labelIntrinsicSize.height+(2.0*PADDING_Y));
+    CGFloat width = labelIntrinsicSize.width+(2.0*PADDING_X);
+    return CGSizeMake(MIN(width, self.maxWidth), labelIntrinsicSize.height+(2.0*PADDING_Y));
 }
 
 - (CGSize)sizeThatFits:(CGSize)size
 {
     CGSize fittingSize = CGSizeMake(size.width-(2.0*PADDING_X), size.height-(2.0*PADDING_Y));
     CGSize labelSize = [self.selectedLabel sizeThatFits:fittingSize];
-    return CGSizeMake(labelSize.width+(2.0*PADDING_X), labelSize.height+(2.0*PADDING_Y));
+    CGFloat width = labelSize.width+(2.0*PADDING_X);
+    return CGSizeMake(MIN(width, self.maxWidth), labelSize.height+(2.0*PADDING_Y));
 }
 
 


### PR DESCRIPTION
expose the textField class so we can actually access it's methods/properties,
handle case where the token's title text is wider than CLTokenInputView's width.